### PR TITLE
Update importer for PEP 451

### DIFF
--- a/six.py
+++ b/six.py
@@ -181,19 +181,17 @@ class _SixMetaPathImporter(object):
 
     def _add_module(self, mod, *fullnames):
         for fullname in fullnames:
-            self.known_modules[self.name + "." + fullname] = mod
+            full = self.name + "." + fullname
+            self.known_modules[full] = mod
+            sys.modules[full] = mod
 
     def _get_module(self, fullname):
         return self.known_modules[self.name + "." + fullname]
 
-    def find_module(self, fullname, path=None):
-        if fullname in self.known_modules:
-            return self
-        return None
-
     def find_spec(self, fullname, path, target=None):
         if fullname in self.known_modules:
-            return spec_from_loader(fullname, self)
+            return spec_from_loader(fullname, self,
+                                   is_package=self.is_package(fullname))
         return None
 
     def __get_module(self, fullname):
@@ -202,19 +200,6 @@ class _SixMetaPathImporter(object):
         except KeyError:
             raise ImportError("This loader does not know module " + fullname)
 
-    def load_module(self, fullname):
-        try:
-            # in case of a reload
-            return sys.modules[fullname]
-        except KeyError:
-            pass
-        mod = self.__get_module(fullname)
-        if isinstance(mod, MovedModule):
-            mod = mod._resolve()
-        else:
-            mod.__loader__ = self
-        sys.modules[fullname] = mod
-        return mod
 
     def is_package(self, fullname):
         """
@@ -234,7 +219,12 @@ class _SixMetaPathImporter(object):
     get_source = get_code  # same as get_code
 
     def create_module(self, spec):
-        return self.load_module(spec.name)
+        mod = self.__get_module(spec.name)
+        if isinstance(mod, MovedModule):
+            mod = mod._resolve()
+        else:
+            mod.__loader__ = self
+        return mod
 
     def exec_module(self, module):
         pass

--- a/test_six.py
+++ b/test_six.py
@@ -1052,3 +1052,18 @@ class EnsureTests:
             assert converted_unicode == self.UNICODE_EMOJI and isinstance(converted_unicode, str)
             # PY3: bytes -> str
             assert converted_binary == self.UNICODE_EMOJI and isinstance(converted_unicode, str)
+
+
+def test_moves_importable_py312():
+    if sys.version_info < (3, 12):
+        pytest.skip("Python 3.12 required")
+    import importlib
+    mod = importlib.import_module('six.moves')
+    assert mod is six.moves
+    sub = importlib.import_module('six.moves.urllib.parse')
+    assert sub is six.moves.urllib.parse
+    pkg = importlib.import_module('six.moves.urllib')
+    assert pkg is six.moves.urllib
+    assert 'six.moves' in sys.modules
+    assert 'six.moves.urllib.parse' in sys.modules
+    assert 'six.moves.urllib' in sys.modules


### PR DESCRIPTION
## Summary
- update the `_SixMetaPathImporter` for Python 3.12
- register modules in `sys.modules` when building the importer
- ensure moves submodules can be imported under Python 3.12

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6848e157cbd4832689c31e1cc35313cf